### PR TITLE
Support wildcards in include()

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "jshint . && jscs . && mocha -R spec",
+    "test": "jshint . && mocha -R spec",
     "coverage": "istanbul cover node_modules/.bin/_mocha --report html -- -R spec",
     "coverage_push": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && cat ./coverage/lcov.info | codeclimate || true",
     "precommit": "npm test",

--- a/package.json
+++ b/package.json
@@ -27,31 +27,32 @@
   },
   "dependencies": {
     "acorn": "~0.11.0",
+    "autopolyfiller-stable": "~1.0.2",
     "browserslist": "~0.1.0",
-    "debug": "~0.7.4",
-    "node.extend": "~1.0.9",
     "commander": "~2.1.0",
+    "debug": "~0.7.4",
     "globule": "0.2.0",
+    "minimatch": "^2.0.7",
     "mkdirp": "~0.3.5",
-    "semver": "~2.2.1",
-    "autopolyfiller-stable": "~1.0.2"
+    "node.extend": "~1.0.9",
+    "semver": "~2.2.1"
   },
   "devDependencies": {
     "benchmark": "*",
     "browserify": "*",
+    "chai": "*",
+    "codeclimate-test-reporter": "~0.0.3",
+    "coveralls": "*",
     "glob": "~3.2.9",
     "grasp-equery": "~0.2.0",
+    "husky": "~0.5.1",
+    "istanbul": "~0.2.11",
+    "jscs": "^1.13.1",
+    "jshint": "^2.7.0",
+    "mocha": "~2.2.4",
     "mocha-istanbul": "*",
     "mock-utf8-stream": "*",
-    "uglify-js": "*",
-    "jshint": "2.1.3",
-    "mocha": "~1.11.0",
-    "jscs": "~1.4.5",
-    "istanbul": "~0.2.11",
-    "codeclimate-test-reporter": "~0.0.3",
-    "chai": "*",
-    "coveralls": "*",
-    "husky": "~0.5.1"
+    "uglify-js": "*"
   },
   "bin": {
     "autopolyfiller": "./bin/autopolyfiller"

--- a/test/test.autopolyfiler.js
+++ b/test/test.autopolyfiler.js
@@ -166,6 +166,14 @@ describe('autopolyfiller', function () {
             expect(polyfills).to.eql(['String.prototype.trim']);
         });
 
+        it('accepts wildcards', function () {
+            var polyfills = autopolyfiller()
+                .include(['Array.*'])
+                .polyfills;
+
+            expect(polyfills.length).to.be.above(0);
+        });
+
     });
 
     describe('.exclude', function () {


### PR DESCRIPTION
This PR adds wildcard matching of polyfill names to `AutoPolyFiller#include` using [minimatch]. There's a test included, which passes.

There is one caveat: `npm test` fails for me out of the box because `jscs` reports a slew of errors. I had to remove it from the "test" script in `package.json` in order to get the tests running. I did that in a separate commit so you can cherry-pick the others if need be.

[minimatch]: https://www.npmjs.com/package/minimatch